### PR TITLE
chore: align issue form labels with site wording

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_blog_post.yml
+++ b/.github/ISSUE_TEMPLATE/3_blog_post.yml
@@ -10,7 +10,7 @@ body:
         Please fill out the form below to submit a blog post request.
 
         - 画像は「本文」欄にドラッグ&ドロップで添付できます。
-          You can drag and drop images into the "本文 (Body)" field.
+          You can drag and drop images into the "本文 / Body" field.
         - 添付画像は自動で `assets/img/posts/` に保存され、本文リンクも自動で置換されます。
           Attached images are automatically saved to `assets/img/posts/`, and links in the post body are rewritten automatically.
         - 公開は管理者レビュー後です。
@@ -19,7 +19,7 @@ body:
   - type: input
     id: post_title
     attributes:
-      label: 投稿タイトル
+      label: 記事タイトル / Post Title
       placeholder: 例）学会発表を行いました
     validations:
       required: true
@@ -27,7 +27,7 @@ body:
   - type: input
     id: post_date
     attributes:
-      label: 投稿日 (YYYY-MM-DD)
+      label: 記事日付 / Article Date (YYYY-MM-DD)
       description: 公開時の記事日付です / Publication date of the post
       placeholder: "2026-03-04"
     validations:
@@ -36,7 +36,7 @@ body:
   - type: dropdown
     id: lang
     attributes:
-      label: 言語
+      label: 言語 / Language
       options:
         - ja
         - en-us
@@ -47,7 +47,7 @@ body:
   - type: input
     id: author
     attributes:
-      label: 投稿者名
+      label: 投稿者 / Author
       placeholder: 例）山田太郎
     validations:
       required: true
@@ -55,7 +55,7 @@ body:
   - type: input
     id: slug
     attributes:
-      label: URLスラッグ（英数字とハイフン、任意）
+      label: URLスラッグ / URL Slug（英数字とハイフン、任意 / optional）
       description: 空欄の場合はタイトルから自動生成します / If empty, it will be generated from the title
       placeholder: 例）conference-report-2026
     validations:
@@ -64,7 +64,7 @@ body:
   - type: input
     id: tags
     attributes:
-      label: タグ（任意、カンマ区切り）
+      label: タグ / Tags（任意 / optional, カンマ区切り / comma-separated）
       placeholder: 例）seminar, fieldwork
     validations:
       required: false
@@ -72,7 +72,7 @@ body:
   - type: input
     id: categories
     attributes:
-      label: カテゴリ（任意、カンマ区切り）
+      label: カテゴリ / Categories（任意 / optional, カンマ区切り / comma-separated）
       placeholder: 例）news
     validations:
       required: false
@@ -80,7 +80,7 @@ body:
   - type: textarea
     id: content
     attributes:
-      label: 本文（Markdown）
+      label: 本文 / Body (Markdown)
       description: Markdownで本文を入力してください。画像添付もここで行えます。 / Write the post body in Markdown. You can also attach images here.
       placeholder: |
         ここに本文を書いてください。
@@ -94,7 +94,7 @@ body:
   - type: checkboxes
     id: consent
     attributes:
-      label: 確認事項
+      label: 確認事項 / Confirmation
       options:
         - label: 投稿内容は研究室サイトに公開可能な内容であることを確認しました。
           required: true

--- a/.github/scripts/create_blog_post_from_issue.py
+++ b/.github/scripts/create_blog_post_from_issue.py
@@ -295,14 +295,67 @@ def main() -> int:
 
     sections = parse_sections(issue_body)
 
-    title = first_non_empty(sections, ["投稿タイトル", "Post title"], required=True)
-    date_str = parse_iso_date(first_non_empty(sections, ["投稿日 (YYYY-MM-DD)", "Post date (YYYY-MM-DD)"], required=True))
-    lang = normalize_language(first_non_empty(sections, ["言語", "Language"], required=False) or "ja")
-    author = first_non_empty(sections, ["投稿者名", "Author"], required=True)
-    requested_slug = first_non_empty(sections, ["URLスラッグ（英数字とハイフン、任意）", "URL slug (optional)"], required=False)
-    tags = parse_csv_list(first_non_empty(sections, ["タグ（任意、カンマ区切り）", "Tags (optional, comma-separated)"], required=False))
-    categories = parse_csv_list(first_non_empty(sections, ["カテゴリ（任意、カンマ区切り）", "Categories (optional, comma-separated)"], required=False))
-    content = first_non_empty(sections, ["本文（Markdown）", "Body (Markdown)"], required=True)
+    title = first_non_empty(
+        sections,
+        ["記事タイトル / Post Title", "投稿タイトル", "Post title"],
+        required=True,
+    )
+    date_str = parse_iso_date(
+        first_non_empty(
+            sections,
+            [
+                "記事日付 / Article Date (YYYY-MM-DD)",
+                "記事日付/Article Date (YYYY-MM-DD)",
+                "投稿日 (YYYY-MM-DD)",
+                "Post date (YYYY-MM-DD)",
+            ],
+            required=True,
+        )
+    )
+    lang = normalize_language(
+        first_non_empty(sections, ["言語 / Language", "言語", "Language"], required=False) or "ja"
+    )
+    author = first_non_empty(
+        sections,
+        ["投稿者 / Author", "投稿者名", "Author"],
+        required=True,
+    )
+    requested_slug = first_non_empty(
+        sections,
+        [
+            "URLスラッグ / URL Slug（英数字とハイフン、任意 / optional）",
+            "URLスラッグ（英数字とハイフン、任意）",
+            "URL slug (optional)",
+        ],
+        required=False,
+    )
+    tags = parse_csv_list(
+        first_non_empty(
+            sections,
+            [
+                "タグ / Tags（任意 / optional, カンマ区切り / comma-separated）",
+                "タグ（任意、カンマ区切り）",
+                "Tags (optional, comma-separated)",
+            ],
+            required=False,
+        )
+    )
+    categories = parse_csv_list(
+        first_non_empty(
+            sections,
+            [
+                "カテゴリ / Categories（任意 / optional, カンマ区切り / comma-separated）",
+                "カテゴリ（任意、カンマ区切り）",
+                "Categories (optional, comma-separated)",
+            ],
+            required=False,
+        )
+    )
+    content = first_non_empty(
+        sections,
+        ["本文 / Body (Markdown)", "本文（Markdown）", "Body (Markdown)"],
+        required=True,
+    )
 
     slug = normalize_slug(requested_slug) if requested_slug else slugify(title)
     if not slug:

--- a/_data/en-us/strings.yml
+++ b/_data/en-us/strings.yml
@@ -124,7 +124,7 @@ no_posts: "No posts yet."
 pagination:
   page: page
 post:
-  created_in: Article date
+  created_in: Article Date
   created_by: by
   last_updated: last updated on
 references: References


### PR DESCRIPTION
## Summary
- make issue form field labels consistently bilingual
- rename date field to `記事日付 / Article Date (YYYY-MM-DD)`
- update parser to support both new labels and legacy labels
- align site English string `post.created_in` to `Article Date`

## Files
- .github/ISSUE_TEMPLATE/3_blog_post.yml
- .github/scripts/create_blog_post_from_issue.py
- _data/en-us/strings.yml

## Validation
- issue form YAML parse OK
- python compile OK
- parser compatibility smoke test (old and new label headings)
