### PR TITLE
feat: auto-derive blog author and simplify submission form

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_blog_post.yml
+++ b/.github/ISSUE_TEMPLATE/3_blog_post.yml
@@ -15,6 +15,12 @@ body:
           Attached images are automatically saved to `assets/img/posts/`, and links in the post body are rewritten automatically.
         - 公開は管理者レビュー後です。
           Publication happens only after maintainer review and approval.
+        - `Add a title` は Issue 管理用です。記事タイトルには `記事タイトル / Post Title` が使われます。
+          `Add a title` is only for issue tracking. `記事タイトル / Post Title` is used as the blog post title.
+        - 投稿者は GitHub ユーザー名から自動取得されます（入力不要）。
+          Author is automatically derived from your GitHub username.
+          例: `kfuku52 (Kenji Fukushima)`（`kfuku52` はプロフィールページへのリンクになります）
+          Example: `kfuku52 (Kenji Fukushima)` where `kfuku52` links to the GitHub profile.
 
   - type: input
     id: post_title
@@ -45,35 +51,11 @@ body:
       required: true
 
   - type: input
-    id: author
-    attributes:
-      label: 投稿者 / Author
-      placeholder: 例）山田太郎
-    validations:
-      required: true
-
-  - type: input
     id: slug
     attributes:
       label: URLスラッグ / URL Slug（英数字とハイフン、任意 / optional）
       description: 空欄の場合はタイトルから自動生成します / If empty, it will be generated from the title
       placeholder: 例）conference-report-2026
-    validations:
-      required: false
-
-  - type: input
-    id: tags
-    attributes:
-      label: タグ / Tags（任意 / optional, カンマ区切り / comma-separated）
-      placeholder: 例）seminar, fieldwork
-    validations:
-      required: false
-
-  - type: input
-    id: categories
-    attributes:
-      label: カテゴリ / Categories（任意 / optional, カンマ区切り / comma-separated）
-      placeholder: 例）news
     validations:
       required: false
 
@@ -96,5 +78,5 @@ body:
     attributes:
       label: 確認事項 / Confirmation
       options:
-        - label: 投稿内容は研究室サイトに公開可能な内容であることを確認しました。
+        - label: 投稿内容は研究室サイトに公開可能な内容であることを確認しました。 / I confirm that this content is suitable for publication on the lab website.
           required: true

--- a/.github/scripts/create_blog_post_from_issue.py
+++ b/.github/scripts/create_blog_post_from_issue.py
@@ -27,6 +27,9 @@ IMAGES_ROOT = REPO_ROOT / "assets" / "img" / "posts"
 SECTION_PATTERN = re.compile(r"^###\s+(.+?)\s*\n([\s\S]*?)(?=^###\s+|\Z)", re.MULTILINE)
 MARKDOWN_IMAGE_PATTERN = re.compile(r"!\[(?P<alt>[^\]]*)\]\((?P<url>https?://[^\s)]+)\)")
 NO_RESPONSE = "_No response_"
+AUTHOR_NAME_OVERRIDES = {
+    "kfuku52": "Kenji Fukushima",
+}
 
 
 class InputError(RuntimeError):
@@ -97,21 +100,17 @@ def normalize_slug(slug: str) -> str:
     return slug
 
 
-def parse_csv_list(value: str) -> List[str]:
-    if not value:
-        return []
-    items = [part.strip() for part in re.split(r"[,\n]", value) if part.strip()]
-    return items
-
-
 def yaml_quote(value: str) -> str:
     return "'" + value.replace("'", "''") + "'"
 
 
-def yaml_inline_list(items: List[str]) -> str:
-    if not items:
-        return ""
-    return "[" + ", ".join(yaml_quote(item) for item in items) + "]"
+def build_author_html(issue_user_login: str) -> str:
+    login = issue_user_login.strip() or "unknown"
+    profile_url = f"https://github.com/{urllib.parse.quote(login)}"
+    display_name = AUTHOR_NAME_OVERRIDES.get(login)
+    if display_name:
+        return f'<a href="{profile_url}">{login}</a> ({display_name})'
+    return f'<a href="{profile_url}">{login}</a>'
 
 
 def is_github_attachment_url(url: str) -> bool:
@@ -252,8 +251,6 @@ def build_markdown(
     title: str,
     date_str: str,
     author: str,
-    tags: List[str],
-    categories: List[str],
     body_markdown: str,
 ) -> str:
     lines = [
@@ -264,8 +261,6 @@ def build_markdown(
         "last_updated:",
         f"author: {yaml_quote(author)}",
         "thumbnail:",
-        f"tags: {yaml_inline_list(tags)}" if tags else "tags:",
-        f"categories: {yaml_inline_list(categories)}" if categories else "categories:",
         "---",
         "",
         body_markdown.rstrip(),
@@ -315,11 +310,7 @@ def main() -> int:
     lang = normalize_language(
         first_non_empty(sections, ["言語 / Language", "言語", "Language"], required=False) or "ja"
     )
-    author = first_non_empty(
-        sections,
-        ["投稿者 / Author", "投稿者名", "Author"],
-        required=True,
-    )
+    author = build_author_html(issue_user)
     requested_slug = first_non_empty(
         sections,
         [
@@ -328,28 +319,6 @@ def main() -> int:
             "URL slug (optional)",
         ],
         required=False,
-    )
-    tags = parse_csv_list(
-        first_non_empty(
-            sections,
-            [
-                "タグ / Tags（任意 / optional, カンマ区切り / comma-separated）",
-                "タグ（任意、カンマ区切り）",
-                "Tags (optional, comma-separated)",
-            ],
-            required=False,
-        )
-    )
-    categories = parse_csv_list(
-        first_non_empty(
-            sections,
-            [
-                "カテゴリ / Categories（任意 / optional, カンマ区切り / comma-separated）",
-                "カテゴリ（任意、カンマ区切り）",
-                "Categories (optional, comma-separated)",
-            ],
-            required=False,
-        )
     )
     content = first_non_empty(
         sections,
@@ -374,8 +343,6 @@ def main() -> int:
         title=title,
         date_str=date_str,
         author=author,
-        tags=tags,
-        categories=categories,
         body_markdown=content,
     )
     post_path.write_text(post_markdown, encoding="utf-8")

--- a/docs/blog-submission.md
+++ b/docs/blog-submission.md
@@ -4,9 +4,15 @@
 
 1. Open the repository Issues page.
 2. Choose `📝 Blog post submission`.
-3. Fill in title/date/author/body.
+3. Fill in post title, article date, language, and body.
 4. Drag and drop images into the body field if needed.
 5. Submit the issue.
+
+Notes:
+
+- `Add a title` in the issue header is for issue tracking only.
+- Blog post title is taken from `記事タイトル / Post Title`.
+- Author is derived automatically from your GitHub username and linked to your profile.
 
 What happens next:
 


### PR DESCRIPTION
## Summary
- add English sentence to the publication consent checkbox
- remove `Author`, `Tags`, and `Categories` fields from blog post issue form
- clarify that `Add a title` is only for issue tracking and post title comes from `記事タイトル / Post Title`
- auto-derive `author` from `issue.user.login`
- generate linked author text in front matter (e.g., `<a href="https://github.com/kfuku52">kfuku52</a> (Kenji Fukushima)`)
- keep `kfuku52 -> Kenji Fukushima` display-name override
- update docs for the new behavior

## Files
- .github/ISSUE_TEMPLATE/3_blog_post.yml
- .github/scripts/create_blog_post_from_issue.py
- docs/blog-submission.md

## Validation
- issue form YAML parse OK
- python compile OK
- smoke test: author auto-derivation + no tags/categories output
