### PR TITLE
chore: clarify article date wording in blog submission

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_blog_post.yml
+++ b/.github/ISSUE_TEMPLATE/3_blog_post.yml
@@ -34,7 +34,7 @@ body:
     id: post_date
     attributes:
       label: 記事日付 / Article Date (YYYY-MM-DD)
-      description: 公開時の記事日付です / Publication date of the post
+      description: 記事ページに表示される日付です（公開日ではありません） / Date shown on the post page (this is not the publication date)
       placeholder: "2026-03-04"
     validations:
       required: true

--- a/docs/blog-submission.md
+++ b/docs/blog-submission.md
@@ -12,6 +12,7 @@ Notes:
 
 - `Add a title` in the issue header is for issue tracking only.
 - Blog post title is taken from `記事タイトル / Post Title`.
+- `記事日付 / Article Date` is the date shown on the post page, not the publication date.
 - Author is derived automatically from your GitHub username and linked to your profile.
 
 What happens next:


### PR DESCRIPTION
## Summary
- clarify `記事日付 / Article Date` wording to avoid confusion with publication date
- explicitly state this is the date shown on the post page, not the publication date
- keep author auto-link behavior unchanged (`kfuku52 -> kfuku52 (Kenji Fukushima)` with profile link)

## Files
- .github/ISSUE_TEMPLATE/3_blog_post.yml
- docs/blog-submission.md
